### PR TITLE
point {{ config.extra.even_title }} target to /

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -32,7 +32,7 @@
 
             <div id="mobile-navbar" class="mobile-navbar">
               <div class="mobile-header-logo">
-                <a href="/example-site/" class="logo">{{ config.extra.even_title }}</a>
+                <a href="/" class="logo">{{ config.extra.even_title }}</a>
               </div>
               <div class="mobile-navbar-icon icon-out">
                 <span></span>


### PR DESCRIPTION
The title should always point to the landing page.